### PR TITLE
Support configuration for span processor type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,16 @@ with tracely.bind_to_trace(trace_id):
 In this case instead of creating new TraceID for events this events will be bound to trace with given TraceID.
 
 **Warning**: in this case TraceID management is in user responsibility, if user provide duplicated TraceID all events would be bound to same trace.
+
+## Additional configuration
+
+There some additional configuration for `tracely`:
+
+### Processor type
+
+`init_tracing(processor_type='batch')`
+
+- `processor_type` can be one of `batch` or `simple` value
+
+`batch` processor - uses batching for deferred sending traces to exporter. Improve performance in large amount of traces but introduces some delay between event happening and sending to server.
+`simple` processor - calls exporter as soon as event ready, so there is no delay between event happening and its sending to server, but can lead to possible performance issues on large amount of events.

--- a/tracely/src/tracely/_tracer_provider.py
+++ b/tracely/src/tracely/_tracer_provider.py
@@ -11,7 +11,7 @@ from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SimpleSpanProcessor
 from opentelemetry.trace import NonRecordingSpan
 from opentelemetry.trace import SpanContext
 from opentelemetry.trace import TraceFlags
@@ -64,6 +64,7 @@ _data_context: DataContext = DataContext("<not_set>", "<not_set>")
 def _create_tracer_provider(
     address: Optional[str] = None,
     exporter_type: Optional[str] = None,
+    processor_type: str = "batch",
     api_key: Optional[str] = None,
     project_id: Optional[Union[str, uuid.UUID]] = None,
     export_name: Optional[str] = None,
@@ -174,7 +175,10 @@ def _create_tracer_provider(
         exporter = InMemorySpanExporter()
     else:
         raise ValueError("Unexpected value of exporter type")
-    tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+    if processor_type == "batch":
+        tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+    elif processor_type == "simple":
+        tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
     _tracer = tracer_provider.get_tracer("evidently")
     return tracer_provider
 
@@ -187,6 +191,7 @@ def init_tracing(
     export_name: Optional[str] = None,
     *,
     as_global: bool = True,
+    processor_type: str = "batch",
     default_usage_details: Optional[UsageDetails] = None,
     usage_details_by_model_id: Optional[Dict[str, UsageDetails]] = None,
 ) -> trace.TracerProvider:
@@ -201,11 +206,18 @@ def init_tracing(
         as_global: indicated when to register provider globally for opentelemetry of use local one
                    Can be useful when you don't want to mix already existing OpenTelemetry tracing with Evidently one,
                    but may require additional configuration
+        processor_type: (default: batch) type of processor to use:
+                        'batch' - upload traces in batches once in several seconds in separate thread
+                        'simple' - upload traces synchronously as it is reported, can cause performance issues.
+        default_usage_details: usage data for tokens
+        usage_details_by_model_id: usage data for tokens by model id (if provided)
+
     """
     global _tracer  # noqa: PLW0603
     provider = _create_tracer_provider(
         address,
         exporter_type,
+        processor_type,
         api_key,
         project_id,
         export_name,

--- a/tracely/src/tracely/_tracer_provider.py
+++ b/tracely/src/tracely/_tracer_provider.py
@@ -179,6 +179,8 @@ def _create_tracer_provider(
         tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
     elif processor_type == "simple":
         tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    else:
+        raise ValueError(f"Unexpected processor type: {processor_type}. Expected values: batch or simple")
     _tracer = tracer_provider.get_tracer("evidently")
     return tracer_provider
 


### PR DESCRIPTION
Add parameter `processor_type` in `init_tracing` to.

Possible values:
- `batch` (default) - use deferred batch processor: spans will be sent in separate thread in batches.
- `simple` - synchronous span processor - calls exported as soon as span is ready (can cause performance issues).

Example:

```python
from tracely import init_tracing

init_tracing(
    ...,
    processor_type="simple",
)
```